### PR TITLE
Make it compatible for RN 0.47

### DIFF
--- a/android/src/main/java/com/github/pgengoux/huaweiprotectedapps/HuaweiProtectedAppsPackage.java
+++ b/android/src/main/java/com/github/pgengoux/huaweiprotectedapps/HuaweiProtectedAppsPackage.java
@@ -22,7 +22,6 @@ public class HuaweiProtectedAppsPackage implements ReactPackage {
         );
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-huawei-protected-apps",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Customized dialog alerting the user of the battery save mode 'Protected Apps' of Huawei smartphones",
   "main": "index.js",
   "directories": {
@@ -31,5 +31,8 @@
   },
   "homepage": "https://github.com/pgengoux/react-native-huawei-protected-apps",
   "dependencies": {
+  },
+  "peerDependencies": {
+    "react-native": ">=0.47"
   }
 }


### PR DESCRIPTION
There is a breaking change about @Override in RN 0.47, if it is not fixed, react-native-huawei-protected-apps can't be used for RN >= 0.47.