### PR TITLE
updated build.gradle and gradle version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,23 +1,32 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
+        mavenLocal()
         mavenCentral()
+        maven { url "$rootDir/../node_modules/react-native/android" }
+        maven { url 'https://maven.google.com' }
+        maven { url "https://jitpack.io" }
+        maven { url 'https://dl.bintray.com/android/android-tools' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
 apply plugin: 'com.android.library'
 
+def DEFAULT_COMPILE_SDK_VERSION = 28
+def DEFAULT_BUILD_TOOLS_VERSION = "28.0.3"
+def DEFAULT_TARGET_SDK_VERSION = 28
+
 android {
-    compileSdkVersion 26
-    buildToolsVersion "27.0.3"
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "0.1.0"
         ndk {
@@ -26,6 +35,17 @@ android {
     }
 }
 
+repositories {
+    google()
+    jcenter()
+    mavenLocal()
+    mavenCentral()
+    maven { url "$rootDir/../node_modules/react-native/android" }
+    maven { url 'https://maven.google.com' }
+    maven { url "https://jitpack.io" }
+    maven { url 'https://dl.bintray.com/android/android-tools' }
+}
+
 dependencies {
-    compile "com.facebook.react:react-native:+"
+    implementation 'com.facebook.react:react-native:+'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Sep 01 13:49:48 CEST 2017
+#Sun Dec 30 10:49:31 WAT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
I've updated the gradle version and added a "best practice" way of defining compileSdkVersion, buildToolsVersion and targetSdkVersion in build.gradle. I've also added a few repos (some of them might not even be needed) because i had an issue with "couldn't resolve com.facebook.react:react-native:+".
The reason for these changes is because I'm having some issues building my react native android app when using this library and i believe this PR should fix that.